### PR TITLE
Modified the android manifest for prevent landscape mode

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,17 +8,24 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
+        <activity
+            android:name=".MainActivity"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".TutorCalendarFragment" />
-
-        <activity android:name=".TutorMainActivity" />
-        <activity android:name=".StudentMainActivity" />
+        <activity
+            android:name=".TutorCalendarFragment"
+            android:screenOrientation="portrait"/>
+        <activity
+            android:name=".TutorMainActivity"
+            android:screenOrientation="portrait"/>
+        <activity
+            android:name=".StudentMainActivity"
+            android:screenOrientation="portrait"/>
     </application>
 
 </manifest>


### PR DESCRIPTION
Added `android:screenOrientation="portrait"` to all of our activities in the manifest to prevent landscape mode.

I read several posts about this and there's much 'debate' on why/why not to do this. There some devices (very few) that run Android and have a default landscape orientation without an option for portrait. Now, this would be an issue if this was a production application for a mass audience but most of these devices (i.e. non-portrait) are tables which isn't our primary device target for this application. That is, we prioritize the usability and functionality for phone devices - or non-table devices.

### Before
![screen shot 2017-03-04 at 9 31 13 pm](https://cloud.githubusercontent.com/assets/6282512/23583790/7e36fb46-0124-11e7-9f28-4dff482b72fb.png)

### After
![screen shot 2017-03-04 at 9 41 11 pm](https://cloud.githubusercontent.com/assets/6282512/23583787/73707660-0124-11e7-8440-b863a0c3fd45.png)
