### PR TITLE
setup-tutor-list-item-views: fixed image display bug

### DIFF
--- a/app/src/main/java/cs/dal/krush/StudentCursorAdapters/BookingTutorCursorAdapter.java
+++ b/app/src/main/java/cs/dal/krush/StudentCursorAdapters/BookingTutorCursorAdapter.java
@@ -2,6 +2,8 @@ package cs.dal.krush.StudentCursorAdapters;
 
 import android.content.Context;
 import android.database.Cursor;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -64,10 +66,9 @@ public class BookingTutorCursorAdapter extends CursorAdapter {
 
         //Get the tutor's profile image:
         String imageFileName = cursor.getString(cursor.getColumnIndexOrThrow("profile_pic"));
-        if (imageFileName != null){
-            int resourceId = mContext.getResources().getIdentifier(
-                    imageFileName, "drawable", mContext.getPackageName());
-            image.setImageResource(resourceId);
+        if(imageFileName != null && !imageFileName.isEmpty()) {
+            Bitmap profile_pic = BitmapFactory.decodeFile(imageFileName);
+            image.setImageBitmap(profile_pic);
         }
 
         //Set the row's header text:

--- a/app/src/main/java/cs/dal/krush/StudentCursorAdapters/HomeQuickBookCursorAdapter.java
+++ b/app/src/main/java/cs/dal/krush/StudentCursorAdapters/HomeQuickBookCursorAdapter.java
@@ -2,6 +2,8 @@ package cs.dal.krush.StudentCursorAdapters;
 
 import android.content.Context;
 import android.database.Cursor;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.graphics.drawable.Drawable;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -65,10 +67,9 @@ public class HomeQuickBookCursorAdapter extends CursorAdapter {
 
         //Get the tutor's profile image:
         String imageFileName = cursor.getString(cursor.getColumnIndexOrThrow("profile_pic"));
-        if (imageFileName != null){
-            int resourceId = mContext.getResources().getIdentifier(
-                    imageFileName, "drawable", mContext.getPackageName());
-            image.setImageResource(resourceId);
+        if(imageFileName != null && !imageFileName.isEmpty()) {
+            Bitmap profile_pic = BitmapFactory.decodeFile(imageFileName);
+            image.setImageBitmap(profile_pic);
         }
 
         //Set the row's header text:

--- a/app/src/main/java/cs/dal/krush/StudentCursorAdapters/SessionCursorAdapter.java
+++ b/app/src/main/java/cs/dal/krush/StudentCursorAdapters/SessionCursorAdapter.java
@@ -2,6 +2,8 @@ package cs.dal.krush.StudentCursorAdapters;
 
 import android.content.Context;
 import android.database.Cursor;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -64,10 +66,9 @@ public class SessionCursorAdapter extends CursorAdapter {
 
         //Get the tutor's profile image:
         String imageFileName = cursor.getString(cursor.getColumnIndexOrThrow("profile_pic"));
-        if (imageFileName != null){
-            int resourceId = mContext.getResources().getIdentifier(
-                    imageFileName, "drawable", mContext.getPackageName());
-            image.setImageResource(resourceId);
+        if(imageFileName != null && !imageFileName.isEmpty()) {
+            Bitmap profile_pic = BitmapFactory.decodeFile(imageFileName);
+            image.setImageBitmap(profile_pic);
         }
 
         //Set the row's header text:

--- a/app/src/main/java/cs/dal/krush/TutorCursorAdapters/SessionCursorAdapter.java
+++ b/app/src/main/java/cs/dal/krush/TutorCursorAdapters/SessionCursorAdapter.java
@@ -2,6 +2,8 @@ package cs.dal.krush.TutorCursorAdapters;
 
 import android.content.Context;
 import android.database.Cursor;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -65,10 +67,9 @@ public class SessionCursorAdapter extends CursorAdapter {
 
         //Get the student's profile image:
         String imageFileName = cursor.getString(cursor.getColumnIndexOrThrow("profile_pic"));
-        if (imageFileName != null){
-            int resourceId = mContext.getResources().getIdentifier(
-                    imageFileName, "drawable", mContext.getPackageName());
-            image.setImageResource(resourceId);
+        if(imageFileName != null && !imageFileName.isEmpty()) {
+            Bitmap profile_pic = BitmapFactory.decodeFile(imageFileName);
+            image.setImageBitmap(profile_pic);
         }
 
         //Set the row's header text:

--- a/app/src/main/java/cs/dal/krush/seeders/StudentSeeder.java
+++ b/app/src/main/java/cs/dal/krush/seeders/StudentSeeder.java
@@ -13,16 +13,16 @@ public class StudentSeeder {
      * @param db
      */
     public static void insert(DBHelper db){
-        db.student.insert(1,"egg1","Greg","Miller","gregpmillr@gmail.com","password");
-        db.student.insert(3,"egg1","John","Wick","jw@gmail.com","password");
-        db.student.insert(2,"egg1","John","Smith","js@gmail.com","password");
-        db.student.insert(4,"egg1","Samuel","Jackson","sj@dal.ca","password");
-        db.student.insert(5,"egg1","Jack","Daniels","jd@outlook.com","password");
-        db.student.insert(6,"egg1","Tim","Thompson","tt@hotmail.ca","password");
-        db.student.insert(7,"egg1","Mike","Jackson","mj@hotmail.ca","password");
-        db.student.insert(8,"egg1","Lucy","Patterson","lp@hotmail.ca","password");
-        db.student.insert(7,"egg1","Carline","Jenkins","mj@hotmail.ca","password");
-        db.student.insert(3,"egg1","McKenzie","Rekker","mk@dal.ca","password");
-        db.student.insert(4,"egg1","Darlene","Tims","dt@gmail.ca","password");
+        db.student.insert(1, null, "Greg", "Miller", "gregpmillr@gmail.com", "password");
+        db.student.insert(3, null, "John", "Wick", "jw@gmail.com", "password");
+        db.student.insert(2, null, "John", "Smith", "js@gmail.com", "password");
+        db.student.insert(4, null, "Samuel", "Jackson", "sj@dal.ca", "password");
+        db.student.insert(5, null, "Jack", "Daniels", "jd@outlook.com", "password");
+        db.student.insert(6, null, "Tim", "Thompson", "tt@hotmail.ca", "password");
+        db.student.insert(7, null, "Mike", "Jackson", "mj@hotmail.ca", "password");
+        db.student.insert(8, null, "Lucy", "Patterson", "lp@hotmail.ca", "password");
+        db.student.insert(7, null, "Carline", "Jenkins", "mj@hotmail.ca", "password");
+        db.student.insert(3, null, "McKenzie", "Rekker", "mk@dal.ca", "password");
+        db.student.insert(4, null, "Darlene", "Tims", "dt@gmail.ca", "password");
     }
 }

--- a/app/src/main/java/cs/dal/krush/seeders/TutorSeeder.java
+++ b/app/src/main/java/cs/dal/krush/seeders/TutorSeeder.java
@@ -13,14 +13,14 @@ public class TutorSeeder {
      * @param db
      */
     public static void insert(DBHelper db){
-        db.tutor.insert(1,1,"egg1","Greg","Miller","gregpmillr@gmail.com","password",2, (float)4);
-        db.tutor.insert(3,2,"egg1","Michael","Casey","mc@dal.ca","password",2, (float)4.5);
-        db.tutor.insert(2,1,"egg1","Orjan","Monsen","om@dal.ca","password",5, (float)4.1);
-        db.tutor.insert(4,5,"egg1","Eric","Desjardins","ed@dal.ca","password",1, (float)3.5);
-        db.tutor.insert(5,3,"egg1","Connor","Walsh","cw@dal.ca","password",4, (float)4);
-        db.tutor.insert(2,2,"egg1","Jack","Reaper","jr@dal.ca","password",2, (float)4.25);
-        db.tutor.insert(5,4,"egg1","Peter","Richards","pr@gmail.com","password",2, (float)3);
-        db.tutor.insert(1,3,"egg1","Bonnie","Trimper","br@gmail.com","password",2, (float)3.75);
-        db.tutor.insert(1,3,"egg1","Eve","Zinck","ez@gmail.com","password",2, (float)3.5);
+        db.tutor.insert(1, 1, null, "Greg", "Miller", "gregpmillr@gmail.com", "password", 2, (float)4);
+        db.tutor.insert(3, 2, null, "Michael", "Casey", "mc@dal.ca", "password", 2, (float)4.5);
+        db.tutor.insert(2, 1, null, "Orjan", "Monsen", "om@dal.ca", "password", 5, (float)4.1);
+        db.tutor.insert(4, 5, null, "Eric", "Desjardins", "ed@dal.ca", "password", 1, (float)3.5);
+        db.tutor.insert(5, 3, null, "Connor", "Walsh", "cw@dal.ca", "password", 4, (float)4);
+        db.tutor.insert(2, 2, null, "Jack", "Reaper", "jr@dal.ca", "password", 2, (float)4.25);
+        db.tutor.insert(5, 4, null, "Peter", "Richards", "pr@gmail.com", "password", 2, (float)3);
+        db.tutor.insert(1, 3, null, "Bonnie", "Trimper", "br@gmail.com", "password", 2, (float)3.75);
+        db.tutor.insert(1, 3, null, "Eve", "Zinck", "ez@gmail.com", "password", 2, (float)3.5);
     }
 }


### PR DESCRIPTION
Images are now displayed everywhere they're supposed to. All the logic was setup for this, so all we had to do was just setting the profile pic seeders to NULL.

This closes #101 

