### PR TITLE
todo-registration-view: Added nullable fields and fixed backstack issue

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,9 +44,6 @@
             </intent-filter>
         </activity>
         <activity
-            android:name=".tutorFragments.TutorAvailabilityFragment"
-            android:screenOrientation="portrait" />
-        <activity
             android:name=".LoginMainActivity"
             android:screenOrientation="portrait" />
         <activity
@@ -59,6 +56,7 @@
             android:windowSoftInputMode="adjustPan" />
         <activity
             android:name=".RegistrationActivity"
+            android:noHistory="true"
             android:screenOrientation="portrait" />
 
         <!--

--- a/app/src/main/java/cs/dal/krush/RegistrationActivity.java
+++ b/app/src/main/java/cs/dal/krush/RegistrationActivity.java
@@ -164,8 +164,7 @@ public class RegistrationActivity extends AppCompatActivity {
 
                     //create user based on their type (student/tutor)
                     if(profileSelected == 1){
-                        // TODO: 2017-03-12 make locationID, profilePic, and Rate nullable fields
-                        mydb.tutor.insert(1, schoolID, "egg1", firstName, lastName, email, password, 0, 0);
+                        mydb.tutor.insert(0, schoolID, null, firstName, lastName, email, password, 0, 0);
                         Intent i = new Intent(RegistrationActivity.this, TutorMainActivity.class);
                         //get the new user we just inserted to the DB and pass the ID to the next activity:
                         Cursor newUser = mydb.tutor.getDataEmail(email, password);
@@ -174,8 +173,7 @@ public class RegistrationActivity extends AppCompatActivity {
                         newUser.close();
                         startActivity(i);
                     } else {
-                        // TODO: 2017-03-12 make locationID, profilePic, and Rate nullable fields
-                        mydb.student.insert(schoolID, "egg1", firstName, lastName, email, password);
+                        mydb.student.insert(schoolID, null, firstName, lastName, email, password);
                         Intent i = new Intent(RegistrationActivity.this, StudentMainActivity.class);
                         //get the new user we just inserted to the DB and pass the ID to the next activity:
                         Cursor newUser = mydb.student.getDataEmail(email, password);

--- a/app/src/main/java/cs/dal/krush/models/Tutor.java
+++ b/app/src/main/java/cs/dal/krush/models/Tutor.java
@@ -30,14 +30,18 @@ public class Tutor extends Table{
     public boolean insert(int locationId, int schoolId, String profilePic, String firstName, String lastName, String
                           email, String password, int rate, float rating){
         ContentValues contentValues = new ContentValues();
-        contentValues.put("location_id", locationId);
+        if (locationId != 0) {
+            contentValues.put("location_id", locationId);
+        }
         contentValues.put("school_id", schoolId);
         contentValues.put("profile_pic", profilePic);
         contentValues.put("f_name", firstName);
         contentValues.put("l_name", lastName);
         contentValues.put("email", email);
         contentValues.put("password", password);
-        contentValues.put("rate", rate);
+        if (rate != 0) {
+            contentValues.put("rate", rate);
+        }
         contentValues.put("rating", rating);
         contentValues.put("revenue", 0.00);
         dbWrite.insert("tutors", null, contentValues);


### PR DESCRIPTION
- Profile picture, rate, and location is now either set to NULL, or not set at all upon user registration
- Removed the registration view from the backstack. When the user registers a new user and hits the android back button, they are now redirected to the login/signup view (our app's main activity).
- Removed a fragment from the activity list in the android manifest file. Was there a specific reason we added this fragment to the activity list in the first place? If so, I'll add it back in! 

This closes #124