### PR TITLE
hotfix: Upcoming Session Titles and Subtitles 

### DIFF
--- a/app/src/main/java/cs/dal/krush/StudentCursorAdapters/SessionCursorAdapter.java
+++ b/app/src/main/java/cs/dal/krush/StudentCursorAdapters/SessionCursorAdapter.java
@@ -83,6 +83,14 @@ public class SessionCursorAdapter extends CursorAdapter {
         String tutorLastName = cursor.getString(cursor.getColumnIndexOrThrow("l_name"));
         String tutorRating = cursor.getString(cursor.getColumnIndexOrThrow("rating"));
         String sessionLocation = cursor.getString(cursor.getColumnIndexOrThrow("location"));
+
+        //remove postal code, city and state if found:
+        if (sessionLocation.contains("B3H")) {
+            sessionLocation = sessionLocation.split("B3H")[0];
+        }
+        if (sessionLocation.contains(",")) {
+            sessionLocation = sessionLocation.split(",")[0];
+        }
         String text2content = " With " + tutorFirstName+" "+tutorLastName+" at "+sessionLocation.split(",")[0];
         subHeader.setText(text2content);
     }

--- a/app/src/main/java/cs/dal/krush/studentFragments/StudentBookingDetailsFragment.java
+++ b/app/src/main/java/cs/dal/krush/studentFragments/StudentBookingDetailsFragment.java
@@ -206,8 +206,7 @@ public class StudentBookingDetailsFragment extends Fragment implements View.OnCl
         String END_TIME = timeCursor.getString(timeCursor.getColumnIndex("end_time"));
 
         //Set a title
-        String TITLE = courseSpinnerView.getSelectedItem().toString() + " with " +
-                name + " at " + location + " on " + timeSpinnerView.getSelectedItem().toString();
+        String TITLE = courseSpinnerView.getSelectedItem().toString();
 
         // Calculate cost
         SimpleDateFormat format = new SimpleDateFormat("yyyy-mm-dd H:mm:ss", Locale.getDefault());

--- a/app/src/main/java/cs/dal/krush/tutorFragments/TutorUpcSessionsDetailsFragment.java
+++ b/app/src/main/java/cs/dal/krush/tutorFragments/TutorUpcSessionsDetailsFragment.java
@@ -120,7 +120,6 @@ public class TutorUpcSessionsDetailsFragment extends Fragment {
                 home.setArguments(bundle);
                 FragmentTransaction transaction = getFragmentManager().beginTransaction();
                 transaction.replace(R.id.tutor_fragment_container, home);
-                transaction.addToBackStack(null);
                 transaction.commit();
             }
         });


### PR DESCRIPTION
## How It Used To Look
<img width="384" alt="screen shot 2017-04-03 at 1 26 31 pm" src="https://cloud.githubusercontent.com/assets/16712579/24620360/cb5da4fe-1873-11e7-97e8-99cc54d3b023.png">
<img width="328" alt="screen shot 2017-04-03 at 1 50 03 pm" src="https://cloud.githubusercontent.com/assets/16712579/24620531/7b555fdc-1874-11e7-8133-ca34b972b8fc.png">


## How It Looks Now
<img width="316" alt="screen shot 2017-04-03 at 1 42 17 pm" src="https://cloud.githubusercontent.com/assets/16712579/24620378/e0b5a16c-1873-11e7-940c-9e0193a2e383.png">
<img width="327" alt="screen shot 2017-04-03 at 1 45 43 pm" src="https://cloud.githubusercontent.com/assets/16712579/24620383/e66f4fc2-1873-11e7-88db-1c7b8599f1a9.png">

## Fixes Made
- When booking a new session, we now remove unimportant information from the title both on the upcoming session view and in the list view. I reduced the title to only the course information, and I removed the postal code from the subtitle in the list view (since only half of it was shown).
- Fixed a backstack bug on the tutor upcoming session details view

